### PR TITLE
Fix: linking for devices without bootloader

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ set(TARGET_CPU ATmega328)
 #  Machine-specific stuff
 set(AVR_DUDE_EXECUTABLE C:/tools/avrdude-6.3-mingw32/avrdude.exe)
 set(AVR_DUDE_PORT COM13)
+set(AVR_OBJCOPY_EXECUTABLE C:/tools/avrdude-6.3-mingw32/avr-objdump.exe)
 #  End of machine-specific stuff
 ###################################
 
@@ -32,7 +33,13 @@ add_executable(${PROJECT_NAME} src/main.cpp)
 #### Uncomment this to see flashing process details
 #set(FLASH_VERBOSE_FLAG "-v")
 
+add_custom_target(LINK
+        ${AVR_OBJCOPY_EXECUTABLE} -j .text -j .data -O binary ${PROJECT_BINARY_DIR}/${PROJECT_NAME} ${PROJECT_BINARY_DIR}/${PROJECT_NAME}.bin
+        DEPENDS ${PROJECT_NAME}
+        COMMENT "Link into a flashable binary")
+
 add_custom_target(FLASH
         ${AVR_DUDE_EXECUTABLE} -p ${TARGET_CPU} -c arduino -b115200 -P ${AVR_DUDE_PORT} ${FLASH_VERBOSE_FLAG} -F -D -U flash:w:${PROJECT_BINARY_DIR}/${PROJECT_NAME}:a
-        DEPENDS ${PROJECT_NAME}
+        DEPENDS LINK
         COMMENT "Flash to ${TARGET_CPU}")
+


### PR DESCRIPTION
I used this repository as a template for my latest project, where I programmed an AVR microcontroller without any bootloader. For days I couldn't tell why my code compiled but when run didn't do anything. Then a friend of mine brought to my attention that in case of flashing without a bootloader an extra objectcopy is required to set up the interrupt vectors as well as the reset vector, as you can see in this example: https://blog.podkalicki.com/how-to-compile-and-burn-the-code-to-avr-chip-on-linuxmacosxwindows/
I don't know if the way I implemented it makes sense at all, but it works. I just hope I can take away some of the frustration of the next person trying to figure out why their code is not working.